### PR TITLE
Added err interrupt handler function for select and prompt 

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -53,7 +53,7 @@ type Prompt struct {
 
 	// InterruptHandler is a function that handles interruptions (Ctrl+C) during the prompt execution.
 	// It takes an error as input and returns a string and an error.
-	InterruptHandler func(error) (string, error)
+	InterruptHandler func(error) error
 
 	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
@@ -242,8 +242,8 @@ func (p *Prompt) Run() (string, error) {
 		rl.Write([]byte(showCursor))
 		rl.Close()
 
-		if err == readline.ErrInterrupt {
-			return p.InterruptHandler(err)
+		if err == ErrInterrupt {
+			return "", p.InterruptHandler(err)
 		}
 
 		return "", err

--- a/prompt.go
+++ b/prompt.go
@@ -51,6 +51,10 @@ type Prompt struct {
 	// the Pointer defines how to render the cursor.
 	Pointer Pointer
 
+	// InterruptHandler is a function that handles interruptions (Ctrl+C) during the prompt execution.
+	// It takes an error as input and returns a string and an error.
+	InterruptHandler func(error) (string, error)
+
 	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
 }
@@ -237,6 +241,11 @@ func (p *Prompt) Run() (string, error) {
 		sb.Flush()
 		rl.Write([]byte(showCursor))
 		rl.Close()
+
+		if err == readline.ErrInterrupt {
+			return p.InterruptHandler(err)
+		}
+
 		return "", err
 	}
 

--- a/select.go
+++ b/select.go
@@ -79,6 +79,10 @@ type Select struct {
 	// A function that determines how to render the cursor
 	Pointer Pointer
 
+	// InterruptHandler is a function that handles interruptions (Ctrl+C) during the prompt execution.
+	// It takes an error as input and returns a string and an error.
+	InterruptHandler func(error) (int, string, error)
+
 	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
 }
@@ -400,6 +404,11 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		sb.Flush()
 		rl.Write([]byte(showCursor))
 		rl.Close()
+
+		if err == readline.ErrInterrupt {
+			return s.InterruptHandler(err)
+		}
+
 		return 0, "", err
 	}
 

--- a/select.go
+++ b/select.go
@@ -81,7 +81,7 @@ type Select struct {
 
 	// InterruptHandler is a function that handles interruptions (Ctrl+C) during the prompt execution.
 	// It takes an error as input and returns a string and an error.
-	InterruptHandler func(error) (int, string, error)
+	InterruptHandler func(error) error
 
 	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
@@ -405,8 +405,8 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		rl.Write([]byte(showCursor))
 		rl.Close()
 
-		if err == readline.ErrInterrupt {
-			return s.InterruptHandler(err)
+		if err == ErrInterrupt {
+			return 0, "", s.InterruptHandler(err)
 		}
 
 		return 0, "", err


### PR DESCRIPTION
For both Select and Prompt, interrupt handler function was added in-order to handle keyboard interrupts gracefully. For every prompt or select we can pass in a function with will be called when ever we receive a keyboard interrupt ( Ctrl+C ) from the user.