### PR TITLE
Add cursorAtEnd option to prompt struct

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -55,6 +55,10 @@ type Prompt struct {
 	// It takes an error as input and returns a string and an error.
 	InterruptHandler func(error) error
 
+	// CursorAtEnd sets whether the cursor should be placed at the end of the input field
+	// when the prompt is displayed. If false, the cursor will be at the beginning.
+	CursorAtEnd bool
+
 	Stdin  io.ReadCloser
 	Stdout io.WriteCloser
 }
@@ -168,6 +172,9 @@ func (p *Prompt) Run() (string, error) {
 	}
 	eraseDefault := input != "" && !p.AllowEdit
 	cur := NewCursor(input, p.Pointer, eraseDefault)
+	if p.CursorAtEnd {
+		cur.End()
+	}
 
 	listen := func(input []rune, pos int, key rune) ([]rune, int, bool) {
 		mutex.Lock()


### PR DESCRIPTION
# Add CursorAtEnd option to Prompt struct
 
## Description
This PR introduces a new `CursorAtEnd` boolean field to the `Prompt` struct. When set to `true`, it positions the cursor at the end of the input field when the prompt is displayed, providing more flexibility in cursor positioning for prompt interactions.
 
## Changes
- Added `CursorAtEnd bool` field to the `Prompt` struct
- Updated relevant logic in the `Run()` method to respect this new option
 
## Motivation
Some users may prefer to have the cursor positioned at the end of the input field by default, especially when editing pre-filled values. This option allows for more customizable and user-friendly prompt behavior.
 
## Usage
Users can now set `CursorAtEnd: true` when creating a new `Prompt` to have the cursor start at the end of the input field